### PR TITLE
set files to dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "lib/**/*"
+    "dist"
   ],
   "scripts": {
     "build": "pkgroll && copyfiles -u 1 ./dist/*.mjs ./assets/demo",


### PR DESCRIPTION
Sorry I forgot to do this when I changed to `pkgroll`, I did a quick test with `npm pack` and installed the library in a test project and made sure both `require()` and `import` syntax work.

If you want to do the same to test it

1. run `npm pack` which will produce a `tgz` file
2. then create a new folder outside of the repo and run `npm init -y`
3. add this to the `package.json`

```
"dependencies": {
    "js-torch": "file:[path to the repo]/js-torch/js-pytorch-0.2.2.tgz"
  },
```

4. then run `npm install` and create a test script. I just used the autograd example.

I tested with both `const { torch } = require("js-torch");` and `import { torch } from "js-torch";`